### PR TITLE
fix(deps): keep numpy installable on CI Python 3.11

### DIFF
--- a/environments/adaption_dakota_qa/adaption_dakota_qa/environment.py
+++ b/environments/adaption_dakota_qa/adaption_dakota_qa/environment.py
@@ -14,7 +14,7 @@ import math
 import re
 from collections import Counter
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import Any, Sequence
 from urllib.request import urlopen
 
 import verifiers as vf

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ google-genai>=2.17.0
 requests>=2.34.2
 
 # Analysis and visualization stack
-numpy>=2.5.1
+# Keep these installable on CI's Python 3.11.
+numpy>=2.2,<2.5
 pandas>=3.0.5
 matplotlib>=3.11.1
 

--- a/tests/test_grammar_task_repair.py
+++ b/tests/test_grammar_task_repair.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

GitHub Actions lint and offline tests run on **Python 3.11** and install `-r requirements.txt`. The current floor `numpy>=2.5.1` cannot resolve there:

```
ERROR: Ignored the following versions that require a different python version:
  2.5.0 Requires-Python >=3.12; 2.5.1 Requires-Python >=3.12; 2.5.2 Requires-Python >=3.12
ERROR: Could not find a version that satisfies the requirement numpy>=2.5.1
ERROR: No matching distribution found for numpy>=2.5.1
```

NumPy 2.5.x officially supports Python 3.12–3.14 only. 2.4.6 is the last line with `cp311` wheels. Prior Tinker runs logged `numpy==2.3.4` or `2.4.1`, not 2.5.

## What changed

- Root `requirements.txt`: `numpy>=2.5.1` → `numpy>=2.2,<2.5`
- One-line comment: keep these installable on CI's Python 3.11
- Left `pandas>=3.0.5` and `matplotlib>=3.11.1` alone after checking PyPI: both declare `Requires-Python >=3.11` and publish `cp311` wheels. They do not force NumPy 2.5.
- Dropped two unused imports that failed ruff after install succeeded, so offline tests can run.
- Did not bump CI to 3.12
- Did not touch `e2b/sandbox_setup/requirements.txt`, wandb run artifacts, grant-clean rubric, JSONL, or Tinker launch defaults

## Other CI install paths

| Workflow | Python | Installs |
| --- | --- | --- |
| `.github/workflows/ci.yml` | 3.11 | `requirements.txt` |
| `docs.yml` / `deploy-docs.yml` | 3.11 | `requirements-docs.txt` → `-r requirements.txt` |
| `publish-release.yml` | 3.11 | `requirements-dev.txt` → `-r requirements.txt` |
| `smoke.yml` | `3.x` | `requirements.txt` |

The NumPy floor was the only 3.12-only pin on those paths.

## Verification

GitHub Actions on this PR (Python **3.11.15**):

- `pip install -r requirements.txt` succeeded
- Ruff Lint: success
- Offline Tests: success
- smoke (`pip install -r requirements.txt`): success

Resolved on CI 3.11.15:

| Package | Resolved |
| --- | --- |
| numpy | 2.4.6 (`cp311` wheel) |
| pandas | 3.0.5 |
| matplotlib | 3.11.1 |
| Pillow | 12.3.0 |
| huggingface-hub | 1.27.0 |

Same versions resolved locally on CPython 3.11.16.

No Dakota text invented, no Tinker relaunch, no JSONL edits.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67ea13d9-2f3d-429c-bdf5-99fadb9d1acb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67ea13d9-2f3d-429c-bdf5-99fadb9d1acb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

