### PR TITLE
Add v3 train merge recipe for grant-clean Tinker rerun

### DIFF
--- a/dakota_rl_training/datasets/grammar_tasks_complete_v3_report.json
+++ b/dakota_rl_training/datasets/grammar_tasks_complete_v3_report.json
@@ -1,0 +1,35 @@
+{
+  "source_complete_v2": "dakota_rl_training/datasets/grammar_tasks_complete_v2.jsonl",
+  "adaptive_filtered": "dakota_rl_training/datasets/adaption_adapted_v2_filtered.jsonl",
+  "frozen_heldout_v1": "dakota_rl_training/datasets/grammar_tasks_heldout.jsonl",
+  "merged_complete_v3": "dakota_rl_training/datasets/grammar_tasks_complete_v3.jsonl",
+  "heldout_v1_untouched": true,
+  "live_rubric_unchanged": true,
+  "v3_jsonl_written": false,
+  "adaptive_filtered_present": false,
+  "constructed_in_this_checkout": false,
+  "local_launch_date": "2026-08-14",
+  "recipe": "scripts/rl/merge_grammar_tasks_v3.py",
+  "before": {
+    "v2_rows": 9287,
+    "adaptive_filtered": 523,
+    "holdout_v1_rows": 1060
+  },
+  "after": {
+    "adaptive_already_in_v2": 192,
+    "adaptive_holdout_blocked": 0,
+    "adaptive_new": 331,
+    "v3_unique_rows": 9618,
+    "reverse_translation_unique": 2265,
+    "v3_train_rows_after_reverse_upsample": 11883,
+    "holdout_v1_rows": 1060
+  },
+  "notes": [
+    "Placeholder report for the 2026-08-14 maintainer-machine launch.",
+    "adaption_adapted_v2_filtered.jsonl is not in this repo, so v3 JSONL was not regenerated here.",
+    "v3 = all v2 rows + Adaptive rows whose (prompt, answer) is new and whose prompt is not in holdout v1, then reverse_translation 2x.",
+    "Holdout v1 is the cebp9acs eval set and was not overwritten.",
+    "The live DakotaGrammarRubric is unchanged. Empty required_affixes still score 0.0.",
+    "No Dakota forms were invented in this checkout."
+  ]
+}

--- a/docs/experiments/TINKER_GRANT_CLEAN_RERUN.md
+++ b/docs/experiments/TINKER_GRANT_CLEAN_RERUN.md
@@ -158,3 +158,12 @@ morphology table, existing gold). It does not invent forms.
 Holdout v1 is byte-identical to the `cebp9acs` eval set. A later speaker-correction
 loop should train on v2 and may keep v1 as the frozen comparison eval, or switch
 eval to holdout v2 once that comparison is no longer needed.
+
+## v3 train merge (Adaptive rows + reverse upsample)
+
+A later local launch (2026-08-14) trained on v3: all v2 rows, plus Adaptive
+rows that are not already in v2 and whose prompt is not in holdout v1, then a
+second copy of every `reverse_translation` row. That recipe is
+`scripts/rl/merge_grammar_tasks_v3.py`. The Adaptive filtered file is not in
+this repo, so v3 JSONL is not regenerated here. See
+`docs/experiments/TINKER_GRANT_CLEAN_V3.md`.

--- a/docs/experiments/TINKER_GRANT_CLEAN_V3.md
+++ b/docs/experiments/TINKER_GRANT_CLEAN_V3.md
@@ -1,0 +1,43 @@
+# Experiment note: grant-clean v3 train JSONL
+
+Language: Dakota grammar and morphology from Stephen Return Riggs, *Dakota-English Dictionary* (1890).
+
+This is a **data merge**, not a rubric change and not a Tinker launch from this checkout. The live scorer in `environments/dakota_grammar_translation/.../environment.py` is unchanged. Frozen holdout v1 (`dakota_rl_training/datasets/grammar_tasks_heldout.jsonl`) stays the eval set.
+
+## Why v3 is not in this repo yet
+
+`dakota_rl_training/datasets/adaption_adapted_v2_filtered.jsonl` is not checked in. Do not invent Adaptive rows or Dakota forms. The v3 train file already exists on the maintainer machine from the recipe below.
+
+## Recipe
+
+`scripts/rl/merge_grammar_tasks_v3.py`:
+
+1. Keep every `grammar_tasks_complete_v2.jsonl` row (9,287).
+2. Append Adaptive rows whose `(prompt, answer)` is not already in v2 and whose prompt is not in holdout v1.
+3. Append a second copy of every `reverse_translation` row (2× upsample).
+
+```bash
+python scripts/rl/merge_grammar_tasks_v3.py
+```
+
+The script refuses to write v3 if the Adaptive filtered file is missing. It never writes holdout v1.
+
+## Local launch (maintainer machine, 2026-08-14)
+
+v3 was launched locally from this recipe. Counts:
+
+| Metric | Count |
+| --- | ---: |
+| v2_rows | 9,287 |
+| adaptive_filtered | 523 |
+| adaptive_already_in_v2 | 192 |
+| adaptive_holdout_blocked | 0 |
+| adaptive_new | 331 |
+| v3_unique_rows | 9,618 |
+| reverse_translation_unique | 2,265 |
+| v3_train_rows_after_reverse_upsample | 11,883 |
+| holdout_v1_rows | 1,060 (untouched) |
+
+`--eval-path` stays `dakota_rl_training/datasets/grammar_tasks_heldout.jsonl`. When `grammar_tasks_complete_v3.jsonl` is committed, point `--dataset-path` at that file and set `recipe_name="dakota1890_grant_clean_v3"` on `train.Config` (required by current `tinker_cookbook`). Until then, `tinker_train.py` keeps the v2 default.
+
+Do not run Tinker from CI or a coding agent unless a human is paying for Tinker.

--- a/scripts/rl/merge_grammar_tasks_v3.py
+++ b/scripts/rl/merge_grammar_tasks_v3.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Merge repaired v2 train JSONL with filtered Adaptive rows into v3.
+
+Recipe (data only; does not change the live rubric):
+
+1. Keep every grammar_tasks_complete_v2.jsonl row.
+2. Append Adaptive rows from adaption_adapted_v2_filtered.jsonl whose
+   (prompt, answer) pair is not already in v2 and whose prompt is not in
+   frozen holdout v1 (grammar_tasks_heldout.jsonl).
+3. Append a second copy of every reverse_translation row (2x upsample).
+
+Does not invent Dakota forms. Does not overwrite holdout v1.
+Refuses to write v3 if the Adaptive filtered file is missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_V2 = ROOT / "dakota_rl_training" / "datasets" / "grammar_tasks_complete_v2.jsonl"
+DEFAULT_ADAPTIVE = (
+    ROOT / "dakota_rl_training" / "datasets" / "adaption_adapted_v2_filtered.jsonl"
+)
+DEFAULT_HOLDOUT = ROOT / "dakota_rl_training" / "datasets" / "grammar_tasks_heldout.jsonl"
+DEFAULT_OUTPUT = ROOT / "dakota_rl_training" / "datasets" / "grammar_tasks_complete_v3.jsonl"
+DEFAULT_REPORT = (
+    ROOT / "dakota_rl_training" / "datasets" / "grammar_tasks_complete_v3_report.json"
+)
+
+REVERSE_TASK = "reverse_translation"
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _prompt(row: dict[str, Any]) -> str:
+    return str(row.get("prompt") or row.get("question") or "").strip()
+
+
+def _answer(row: dict[str, Any]) -> str:
+    return str(row.get("answer") or "").strip()
+
+
+def _pair(row: dict[str, Any]) -> tuple[str, str]:
+    return (_prompt(row), _answer(row))
+
+
+def _task_type(row: dict[str, Any]) -> str:
+    info = row.get("info") if isinstance(row.get("info"), dict) else {}
+    return str(info.get("task_type") or row.get("task_type") or "")
+
+
+def merge_v3_rows(
+    v2_rows: list[dict[str, Any]],
+    adaptive_rows: list[dict[str, Any]],
+    holdout_rows: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Build unique v3 rows, then 2x-upsample reverse_translation."""
+
+    v2_pairs = {_pair(row) for row in v2_rows}
+    holdout_prompts = {_prompt(row) for row in holdout_rows}
+
+    unique: list[dict[str, Any]] = [copy.deepcopy(row) for row in v2_rows]
+    seen_pairs = set(v2_pairs)
+    adaptive_already_in_v2 = 0
+    adaptive_holdout_blocked = 0
+    adaptive_new = 0
+
+    for row in adaptive_rows:
+        pair = _pair(row)
+        if pair in v2_pairs:
+            adaptive_already_in_v2 += 1
+            continue
+        if _prompt(row) in holdout_prompts:
+            adaptive_holdout_blocked += 1
+            continue
+        if pair in seen_pairs:
+            continue
+        unique.append(copy.deepcopy(row))
+        seen_pairs.add(pair)
+        adaptive_new += 1
+
+    reverse_rows = [row for row in unique if _task_type(row) == REVERSE_TASK]
+    train_rows = unique + [copy.deepcopy(row) for row in reverse_rows]
+
+    report = {
+        "v2_rows": len(v2_rows),
+        "adaptive_filtered": len(adaptive_rows),
+        "adaptive_already_in_v2": adaptive_already_in_v2,
+        "adaptive_holdout_blocked": adaptive_holdout_blocked,
+        "adaptive_new": adaptive_new,
+        "v3_unique_rows": len(unique),
+        "v3_train_rows_after_reverse_upsample": len(train_rows),
+        "reverse_translation_unique": len(reverse_rows),
+        "holdout_v1_rows": len(holdout_rows),
+    }
+    return train_rows, report
+
+
+def build_report(
+    counts: dict[str, Any],
+    *,
+    v3_written: bool,
+    adaptive_path: Path,
+    output_path: Path,
+) -> dict[str, Any]:
+    return {
+        "source_complete_v2": "dakota_rl_training/datasets/grammar_tasks_complete_v2.jsonl",
+        "adaptive_filtered": "dakota_rl_training/datasets/adaption_adapted_v2_filtered.jsonl",
+        "frozen_heldout_v1": "dakota_rl_training/datasets/grammar_tasks_heldout.jsonl",
+        "merged_complete_v3": "dakota_rl_training/datasets/grammar_tasks_complete_v3.jsonl",
+        "heldout_v1_untouched": True,
+        "live_rubric_unchanged": True,
+        "v3_jsonl_written": v3_written,
+        "adaptive_filtered_present": adaptive_path.is_file(),
+        "output_path": str(output_path),
+        "before": {
+            "v2_rows": counts["v2_rows"],
+            "adaptive_filtered": counts["adaptive_filtered"],
+            "holdout_v1_rows": counts["holdout_v1_rows"],
+        },
+        "after": {
+            "adaptive_already_in_v2": counts["adaptive_already_in_v2"],
+            "adaptive_holdout_blocked": counts["adaptive_holdout_blocked"],
+            "adaptive_new": counts["adaptive_new"],
+            "v3_unique_rows": counts["v3_unique_rows"],
+            "reverse_translation_unique": counts["reverse_translation_unique"],
+            "v3_train_rows_after_reverse_upsample": counts[
+                "v3_train_rows_after_reverse_upsample"
+            ],
+            "holdout_v1_rows": counts["holdout_v1_rows"],
+        },
+        "notes": [
+            "v3 = all v2 rows + Adaptive rows whose (prompt, answer) is new "
+            "and whose prompt is not in holdout v1, then reverse_translation 2x.",
+            "Holdout v1 is the cebp9acs eval set and must not be overwritten.",
+            "The live DakotaGrammarRubric is unchanged. Empty required_affixes still score 0.0.",
+            "This script copies existing attested rows only. It does not invent Dakota forms.",
+        ],
+    }
+
+
+def merge_v3_files(
+    v2_path: Path,
+    adaptive_path: Path,
+    holdout_path: Path,
+    output_path: Path,
+    report_path: Path,
+) -> dict[str, Any]:
+    if output_path.resolve() == holdout_path.resolve():
+        raise ValueError("Refusing to write v3 over frozen holdout v1.")
+    if not adaptive_path.is_file():
+        raise FileNotFoundError(
+            f"Adaptive filtered file is missing: {adaptive_path}. "
+            "Do not invent v3 rows. Place adaption_adapted_v2_filtered.jsonl "
+            "next to the v2 train JSONL, then rerun this script."
+        )
+
+    v2_rows = load_jsonl(v2_path)
+    adaptive_rows = load_jsonl(adaptive_path)
+    holdout_rows = load_jsonl(holdout_path)
+    train_rows, counts = merge_v3_rows(v2_rows, adaptive_rows, holdout_rows)
+    write_jsonl(output_path, train_rows)
+    report = build_report(
+        counts,
+        v3_written=True,
+        adaptive_path=adaptive_path,
+        output_path=output_path,
+    )
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--v2-path", type=Path, default=DEFAULT_V2)
+    parser.add_argument("--adaptive-path", type=Path, default=DEFAULT_ADAPTIVE)
+    parser.add_argument("--holdout-path", type=Path, default=DEFAULT_HOLDOUT)
+    parser.add_argument("--output-path", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--report-path", type=Path, default=DEFAULT_REPORT)
+    args = parser.parse_args()
+
+    holdout = args.holdout_path.resolve()
+    if holdout != DEFAULT_HOLDOUT.resolve() and holdout.name == "grammar_tasks_heldout.jsonl":
+        print(
+            f"Refusing to use a non-default holdout v1 path: {args.holdout_path}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        report = merge_v3_files(
+            args.v2_path.resolve(),
+            args.adaptive_path.resolve(),
+            args.holdout_path.resolve(),
+            args.output_path.resolve(),
+            args.report_path.resolve(),
+        )
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_merge_grammar_tasks_v3.py
+++ b/tests/test_merge_grammar_tasks_v3.py
@@ -1,0 +1,200 @@
+"""v3 merge copies existing rows only; frozen holdout v1 stays byte-identical."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_RL = ROOT / "scripts" / "rl"
+if str(SCRIPTS_RL) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_RL))
+
+from merge_grammar_tasks_v3 import (  # noqa: E402
+    DEFAULT_ADAPTIVE,
+    DEFAULT_OUTPUT,
+    merge_v3_files,
+    merge_v3_rows,
+)
+
+HELD_OUT_V1 = ROOT / "dakota_rl_training" / "datasets" / "grammar_tasks_heldout.jsonl"
+COMPLETE_V2 = ROOT / "dakota_rl_training" / "datasets" / "grammar_tasks_complete_v2.jsonl"
+TINKER_TRAIN = ROOT / "dakota_rl_training" / "tinker_train.py"
+REPORT = ROOT / "dakota_rl_training" / "datasets" / "grammar_tasks_complete_v3_report.json"
+
+
+def _load_jsonl(path: Path) -> list[dict]:
+    rows = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def _git_blob_sha256(relpath: str) -> str:
+    payload = subprocess.check_output(
+        ["git", "show", f"HEAD:{relpath}"],
+        cwd=ROOT,
+    )
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _row(prompt: str, answer: str, task_type: str = "word_translation") -> dict:
+    return {
+        "prompt": prompt,
+        "answer": answer,
+        "info": {"task_type": task_type, "difficulty": "easy"},
+    }
+
+
+def test_frozen_holdout_v1_is_byte_identical_to_head() -> None:
+    current = hashlib.sha256(HELD_OUT_V1.read_bytes()).hexdigest()
+    head = _git_blob_sha256("dakota_rl_training/datasets/grammar_tasks_heldout.jsonl")
+    assert current == head
+    assert len(_load_jsonl(HELD_OUT_V1)) == 1060
+
+
+def test_adaptive_filtered_and_v3_jsonl_are_not_invented_in_repo() -> None:
+    assert not DEFAULT_ADAPTIVE.is_file()
+    assert not DEFAULT_OUTPUT.is_file()
+
+
+def test_tinker_train_keeps_v2_default_until_v3_is_committed() -> None:
+    text = TINKER_TRAIN.read_text(encoding="utf-8")
+    assert "grammar_tasks_complete_v2.jsonl" in text
+    assert "grammar_tasks_complete_v3.jsonl" not in text
+    assert "grammar_tasks_heldout.jsonl" in text
+
+
+def test_placeholder_report_documents_local_launch_counts() -> None:
+    report = json.loads(REPORT.read_text(encoding="utf-8"))
+    assert report["heldout_v1_untouched"] is True
+    assert report["live_rubric_unchanged"] is True
+    assert report["v3_jsonl_written"] is False
+    assert report["before"]["v2_rows"] == 9287
+    assert report["before"]["adaptive_filtered"] == 523
+    assert report["after"]["adaptive_already_in_v2"] == 192
+    assert report["after"]["adaptive_holdout_blocked"] == 0
+    assert report["after"]["adaptive_new"] == 331
+    assert report["after"]["v3_unique_rows"] == 9618
+    assert report["after"]["reverse_translation_unique"] == 2265
+    assert report["after"]["v3_train_rows_after_reverse_upsample"] == 11883
+    assert report["after"]["holdout_v1_rows"] == 1060
+    assert len(_load_jsonl(COMPLETE_V2)) == 9287
+
+
+def test_merge_keeps_v2_adds_new_adaptive_and_blocks_holdout_prompts() -> None:
+    v2 = [
+        _row("Translate kaška", "to bind"),
+        _row("English for pidá", "glad", "reverse_translation"),
+    ]
+    holdout = [_row("Held-out prompt", "held-out gold")]
+    adaptive = [
+        _row("Translate kaška", "to bind"),
+        _row("Held-out prompt", "a different gold"),
+        _row("English for wópida", "gladness", "reverse_translation"),
+        _row("Identify šni", "[verb] šni", "identify_pattern"),
+    ]
+
+    train, counts = merge_v3_rows(v2, adaptive, holdout)
+
+    assert counts["v2_rows"] == 2
+    assert counts["adaptive_filtered"] == 4
+    assert counts["adaptive_already_in_v2"] == 1
+    assert counts["adaptive_holdout_blocked"] == 1
+    assert counts["adaptive_new"] == 2
+    assert counts["v3_unique_rows"] == 4
+    assert counts["reverse_translation_unique"] == 2
+    assert counts["v3_train_rows_after_reverse_upsample"] == 6
+    assert counts["holdout_v1_rows"] == 1
+
+    unique_pairs = [(row["prompt"], row["answer"]) for row in train[:4]]
+    assert unique_pairs == [
+        ("Translate kaška", "to bind"),
+        ("English for pidá", "glad"),
+        ("English for wópida", "gladness"),
+        ("Identify šni", "[verb] šni"),
+    ]
+    assert [row["answer"] for row in train[4:]] == ["glad", "gladness"]
+    assert all(
+        (row.get("info") or {}).get("task_type") == "reverse_translation"
+        for row in train[4:]
+    )
+    assert "Held-out prompt" not in {row["prompt"] for row in train}
+
+
+def test_merge_refuses_missing_adaptive_and_holdout_overwrite(tmp_path: Path) -> None:
+    v2_path = tmp_path / "v2.jsonl"
+    holdout_path = tmp_path / "grammar_tasks_heldout.jsonl"
+    missing_adaptive = tmp_path / "adaption_adapted_v2_filtered.jsonl"
+    output_path = tmp_path / "v3.jsonl"
+    report_path = tmp_path / "report.json"
+
+    v2_path.write_text(
+        json.dumps(_row("Translate kaška", "to bind"), ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    holdout_bytes = (
+        json.dumps(_row("Held-out prompt", "held-out gold"), ensure_ascii=False) + "\n"
+    ).encode("utf-8")
+    holdout_path.write_bytes(holdout_bytes)
+
+    with pytest.raises(FileNotFoundError, match="Do not invent v3 rows"):
+        merge_v3_files(v2_path, missing_adaptive, holdout_path, output_path, report_path)
+    assert not output_path.exists()
+    assert holdout_path.read_bytes() == holdout_bytes
+
+    with pytest.raises(ValueError, match="holdout"):
+        merge_v3_files(v2_path, missing_adaptive, holdout_path, holdout_path, report_path)
+    assert holdout_path.read_bytes() == holdout_bytes
+
+
+def test_merge_writes_v3_from_existing_rows_only(tmp_path: Path) -> None:
+    v2_path = tmp_path / "v2.jsonl"
+    adaptive_path = tmp_path / "adaption_adapted_v2_filtered.jsonl"
+    holdout_path = tmp_path / "holdout.jsonl"
+    output_path = tmp_path / "v3.jsonl"
+    report_path = tmp_path / "report.json"
+
+    v2_rows = [
+        _row("Translate kaška", "to bind"),
+        _row("English for pidá", "glad", "reverse_translation"),
+    ]
+    adaptive_rows = [
+        _row("English for wópida", "gladness", "reverse_translation"),
+    ]
+    holdout_rows = [_row("Held-out prompt", "held-out gold")]
+
+    v2_path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in v2_rows),
+        encoding="utf-8",
+    )
+    adaptive_path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in adaptive_rows),
+        encoding="utf-8",
+    )
+    holdout_path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in holdout_rows),
+        encoding="utf-8",
+    )
+
+    report = merge_v3_files(v2_path, adaptive_path, holdout_path, output_path, report_path)
+    written = _load_jsonl(output_path)
+    assert report["v3_jsonl_written"] is True
+    assert report["after"]["v3_unique_rows"] == 3
+    assert report["after"]["v3_train_rows_after_reverse_upsample"] == 5
+    assert [row["answer"] for row in written] == [
+        "to bind",
+        "glad",
+        "gladness",
+        "glad",
+        "gladness",
+    ]
+    assert holdout_path.read_text(encoding="utf-8").count("\n") == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Adaptive filtered file is not in this repo, so this PR does **not** invent or commit `grammar_tasks_complete_v3.jsonl`. It records the local 2026-08-14 launch recipe and counts so the maintainer-machine v3 file can be reproduced later.

## What landed

- `scripts/rl/merge_grammar_tasks_v3.py`: v2 + filtered Adaptive rows whose `(prompt, answer)` is new and whose prompt is not in holdout v1, then `reverse_translation` 2× upsample. Refuses to write v3 if Adaptive is missing. Never writes holdout v1.
- `docs/experiments/TINKER_GRANT_CLEAN_V3.md`: v3 was launched locally from that recipe.
- `dakota_rl_training/datasets/grammar_tasks_complete_v3_report.json`: placeholder report with the local launch counts.
- Tests for the merge recipe, missing-Adaptive refusal, and holdout freeze.

## Explicitly not changed

- Live rubric (`DakotaGrammarRubric`) is untouched.
- Frozen holdout v1 (`dakota_rl_training/datasets/grammar_tasks_heldout.jsonl`) is byte-identical.
- `tinker_train.py` still defaults `--dataset-path` to v2 and `--eval-path` to holdout v1. `recipe_name="dakota1890_grant_clean_v3"` should be set only when v3 JSONL is committed.

## Local launch counts (2026-08-14)

| Metric | Count |
| --- | ---: |
| v2_rows | 9287 |
| adaptive_filtered | 523 |
| adaptive_already_in_v2 | 192 |
| adaptive_holdout_blocked | 0 |
| adaptive_new | 331 |
| v3_unique_rows | 9618 |
| reverse_translation_unique | 2265 |
| v3_train_rows_after_reverse_upsample | 11883 |
| holdout_v1_rows | 1060 (untouched) |

When `adaption_adapted_v2_filtered.jsonl` is added, run:

```bash
python scripts/rl/merge_grammar_tasks_v3.py
```

Do not launch Tinker from this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d51076ec-d582-4665-9b9d-c2aa4d607292?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d51076ec-d582-4665-9b9d-c2aa4d607292&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

