### PR TITLE
Fix extract_final_answer crash on empty "Final answer is" spans

### DIFF
--- a/environments/dakota_grammar_translation/dakota_grammar_translation/train_reward.py
+++ b/environments/dakota_grammar_translation/dakota_grammar_translation/train_reward.py
@@ -59,11 +59,29 @@ def completion_text(completion: Any) -> str:
     return str(completion)
 
 
+def _first_nonempty_line(span: str) -> str:
+    """Return the first non-empty line of ``span``, or ``""``.
+
+    Never indexes ``splitlines()`` when the span is empty after strip. A
+    whitespace-only ``Final answer is`` / ``Final answer:`` capture used to
+    raise ``IndexError`` and kill Tinker group rollouts (W&B ``h67qxtne``).
+    """
+    cleaned = span.strip()
+    if not cleaned:
+        return ""
+    lines = cleaned.splitlines()
+    if not lines:
+        return ""
+    return lines[0].strip()
+
+
 def extract_final_answer(text: str) -> str:
     """Return the span that should be scored as the model's answer.
 
-    Priority: last ``\\boxed{...}``, then last ``final answer is/`` line,
-    then the last non-empty line, then the stripped text.
+    Priority: last ``\\boxed{...}``, then last non-empty ``final answer is/``
+    capture, then the last non-empty line, then the stripped text.
+    Empty ``FINAL_ANSWER_RE`` captures are skipped so the scorer can fall
+    through instead of crashing.
     """
     if not text or not str(text).strip():
         return ""
@@ -71,8 +89,10 @@ def extract_final_answer(text: str) -> str:
     if boxed:
         return boxed[-1].group(1).strip()
     finals = list(FINAL_ANSWER_RE.finditer(text))
-    if finals:
-        return finals[-1].group(1).strip().splitlines()[0].strip()
+    for match in reversed(finals):
+        span = _first_nonempty_line(match.group(1))
+        if span:
+            return span
     lines = [line.strip() for line in str(text).strip().splitlines() if line.strip()]
     if not lines:
         return ""

--- a/tests/test_grant_clean_reward.py
+++ b/tests/test_grant_clean_reward.py
@@ -89,6 +89,32 @@ def test_extract_final_answer_prefers_boxed_then_final_then_last_line() -> None:
     assert extract_final_answer("") == ""
 
 
+def test_extract_final_answer_empty_marker_does_not_indexerror() -> None:
+    """Whitespace-only FINAL_ANSWER_RE captures must not crash scoring.
+
+    Grant-clean v3b (W&B h67qxtne) died when the last match was
+    ``Final answer is`` / ``Final answer:`` followed only by whitespace:
+    ``group(1).strip()`` was ``""`` and ``splitlines()[0]`` raised
+    ``IndexError``. Walk earlier matches, then the last non-empty line.
+    """
+    no_span = extract_final_answer("reasoning about the suffix\nFinal answer is")
+    assert no_span == "Final answer is"
+
+    whitespace_only = extract_final_answer("reasoning about the suffix\nFinal answer:   ")
+    assert whitespace_only == "Final answer:"
+
+    # ``(?:is|:)`` is exclusive, so "is:" leaves the colon in the capture.
+    normal = extract_final_answer("reasoning about the suffix\nFinal answer is: foo")
+    assert normal == ": foo"
+
+    earlier = extract_final_answer("Final answer is Dawid suŋkaku\nFinal answer is   ")
+    assert earlier == "Dawid suŋkaku"
+
+    scored = score_train_reward("Final answer:   \n", GOLD, INFO)
+    assert scored["answer_span"] == "Final answer:"
+    assert scored["passed"] is False
+
+
 def test_legacy_semantic_pays_gold_substring_in_fluff() -> None:
     assert legacy_semantic_accuracy(GOLD_STUFFED_COT, GOLD) == pytest.approx(1.0)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Grant-clean v3b (W&B `h67qxtne`) died during a Tinker group rollout when the model wrote `Final answer is` / `Final answer:` followed only by whitespace.

`extract_final_answer` did:

```python
return finals[-1].group(1).strip().splitlines()[0].strip()
```

`group(1).strip()` was `""`, so `splitlines()[0]` raised `IndexError` and killed the run.

## Fix

In `dakota_grammar_translation/train_reward.py`:

- If the last `FINAL_ANSWER_RE` match is empty after strip, walk earlier matches.
- If none have a non-empty first line, fall through to the existing last-non-empty-line logic.
- Never index an empty `splitlines()`.

## Explicitly not changed

- Live rubric weights (`exact` 0.40, `char` 0.20, `pattern` 0.15, `affix` 0.10).
- Frozen holdout v1 (`dakota_rl_training/datasets/grammar_tasks_heldout.jsonl`).
- No invented Dakota. The walk-back case reuses the existing kinship gold `Dawid suŋkaku`.
- Training is not launched from this PR.

## Tests

`tests/test_grant_clean_reward.py` covers:

- `"Final answer is"` with no span (regex does not match; last non-empty line).
- `"Final answer:"` plus whitespace (empty capture; fall through, no `IndexError`).
- Normal `"Final answer is: foo"` (still extracts the capture).
- Earlier non-empty match wins when the last capture is whitespace-only.
- `score_train_reward` on a whitespace-only marker does not crash.

Verified locally:

```bash
python3 -m pytest tests/test_grant_clean_reward.py tests/test_grammar_tasks_v2_quality.py::test_frozen_holdout_v1_is_byte_identical_to_head
```

23 passed. Holdout v1 remains byte-identical to `HEAD`.

Do not launch Tinker from this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07238f28-1603-4463-b8d0-0829c1cfa4a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07238f28-1603-4463-b8d0-0829c1cfa4a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

